### PR TITLE
Add `callDetailsOf` helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "testtriple",
-  "version": "2.2.3",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testtriple",
-      "version": "2.2.3",
+      "version": "3.0.1",
       "license": "MIT",
-      "dependencies": {
-        "utility-types": "^3.10.0"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.9",
         "@types/node": "^20.9.3",
@@ -3837,14 +3834,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6848,11 +6837,6 @@
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
-    },
-    "utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "email": "patrik.stutz@gmail.com"
   },
   "license": "MIT",
-  "dependencies": {
-    "utility-types": "^3.10.0"
-  },
   "devDependencies": {
     "@types/jest": "^29.5.9",
     "@types/node": "^20.9.3",

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ console.log(bob.getAge()); // throws "he's dead, jim!"
 
 ## verifying calls
 
-testtriple doesn't do any assertions. But it gives you access to function calls and their parameters using `callsOf`, `callsOfAll` and `callOrderOf`. You can then assert these calls using the test runner of your choice.
+testtriple doesn't do any assertions. But it gives you access to function calls and their parameters using `callsOf`, `callsOfAll`, `callOrderOf`, and `callDetailsOf`. You can then assert these calls using the test runner of your choice.
 
 ### callsOf(fn)
 
@@ -209,6 +209,28 @@ expect(callOrderOf(math.add, math.multiply)).toStrictEqual([
   math.multiply,
   math.add,
 ]);
+```
+
+### callDetailsOf(fn)
+
+Used to simply verify the number of times a single function was called.
+
+```ts
+import { mock, spy, callsOf } from "testtriple";
+
+const math = mock<Calulator>({
+  add: spy(),
+  multiply: spy(),
+});
+
+math.add(1, 2);
+math.multiply(2, 2);
+math.add(3, 8);
+
+const { called, callCount } = callDetailsOf(math.add);
+
+expect(called).toBe(true);
+expect(callCount).toBe(2);
 ```
 
 ## comparison to `testdouble` and `@fluffy-spoon/substitute`

--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,7 @@ expect(callOrderOf(math.add, math.multiply)).toStrictEqual([
 Used to simply verify the number of times a single function was called.
 
 ```ts
-import { mock, spy, callsOf } from "testtriple";
+import { mock, spy, callDetailsOf } from "testtriple";
 
 const math = mock<Calulator>({
   add: spy(),

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -8,6 +8,7 @@ import {
   rejects,
   callOrderOf,
   callsOfAll,
+  callDetailsOf,
 } from ".";
 import { spawnSync } from "child_process";
 
@@ -227,6 +228,25 @@ describe("callsOf, callsOfAll, callOrderOf", () => {
     const secondArgOfFirstCall: number = callsOf(fn)[0][1];
     expect(firstArgOfSecondCall).toBe("2");
     expect(secondArgOfFirstCall).toBe(1);
+  });
+});
+
+describe("callDetailsOf", () => {
+  it("returns the correct call details", () => {
+    const fn = spy();
+    fn();
+    fn();
+    fn();
+    const details = callDetailsOf(fn);
+    expect(details.called).toBe(true);
+    expect(details.callCount).toBe(3);
+  });
+
+  it("returns the correct call details for a function that was never called", () => {
+    const fn = spy();
+    const details = callDetailsOf(fn);
+    expect(details.called).toBe(false);
+    expect(details.callCount).toBe(0);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,3 +104,16 @@ export function callOrderOf(
 ): Array<(...args: any) => any> {
   return getOrderedCalls(...functions).map((call) => call.function);
 }
+
+type Details = {
+  called: boolean;
+  callCount: number;
+};
+
+export function callDetailsOf(fn: (...args: any) => any): Details {
+  const details = callsOf(fn);
+  return {
+    called: details.length > 0,
+    callCount: details.length,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-import { PromiseType } from "utility-types";
+type AsyncFunction = (...args: any[]) => Promise<any>;
+
+type AsyncReturnType<T extends AsyncFunction> = Awaited<ReturnType<T>>;
 
 type AnyFunction = (...args: any[]) => any;
 
@@ -62,11 +64,9 @@ export function throws<T>(err: any): Extract<T, AnyFunction> {
   }) as any as any) as any;
 }
 export function resolves<T>(
-  ...args: PromiseType<
-    ReturnType<Extract<T, AnyFunction>>
-  > extends void
+  ...args: AsyncReturnType<Extract<T, AnyFunction>> extends void
     ? []
-    : [PromiseType<ReturnType<Extract<T, AnyFunction>>>]
+    : [AsyncReturnType<Extract<T, AnyFunction>>]
 ): Extract<T, AnyFunction> {
   return spy<T>((() => Promise.resolve(args[0])) as any) as any;
 }


### PR DESCRIPTION
Closes #4.

Adds a `callDetailsOf` helper to conviently compute details about a spy:

> `callDetailsOf: (fn: AnyFunction) => { called: boolean; callCount: number }`
>
> Used to simply verify the number of times a single function was called.
> 
> ```ts
> import { mock, spy, callDetailsOf } from "testtriple";
>
> const math = mock<Calulator>({
>   add: spy(),
>   multiply: spy(),
> });
>
> math.add(1, 2);
> math.multiply(2, 2);
> math.add(3, 8);
>
> const { called, callCount } = callDetailsOf(math.add);
>
> expect(called).toBe(true);
> expect(callCount).toBe(2);
> ```

Also simplifies some types and removes the `utility-types` dependency.